### PR TITLE
Correct nlmixr entry, add rxode2

### DIFF
--- a/openpharma_included.yaml
+++ b/openpharma_included.yaml
@@ -101,8 +101,11 @@ Merck:
     lang: r
     type: 
       - clinical-statistics
-nlmixrdevelopment:
-  nlmixr:
+nlmixr2:
+  nlmixr2:
+    lang: r
+    type: pkpd
+  rxode2:
     lang: r
     type: pkpd
 Novartis:


### PR DESCRIPTION
The current version of the openpharma site points users to the original version of nlmixr, which is no longer maintained. nlmixr2 is the version being taken forward - would appreicate this being updated. Also, have added an entry for rxode2, which is a package for simulating from ODE-based PK/PD models.